### PR TITLE
Add support for hash params using #! instead of #

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -264,7 +264,16 @@ export function getOrigin(urlComp) {
  */
 export function getURLParam(url, name) {
   const urlComp = urlComponents(url);
-  const paramLocations = [urlComp.hash.slice(1), urlComp.search.slice(1)];
+
+  // urlComp.search is like "?psicash=etc"
+  const qp = urlComp.search.slice(1);
+  // urlComp.hash is like "#psicash=etc" or "#!psicash=etc"
+  let hash = urlComp.hash.slice(1);
+  if (hash.slice(0, 1) === '!') {
+    hash = hash.slice(1);
+  }
+
+  const paramLocations = [hash, qp];
 
   const reString = '(?:^|&)' + name + '=(.+?)(?:&|$)';
   const re = new RegExp(reString);

--- a/src/page.js
+++ b/src/page.js
@@ -126,7 +126,7 @@ function getPsiCashParams() {
 function loadIframe() {
   const iframeURLPath = psicashParams_.debug ? IFRAME_URL_PATH_DEBUG : IFRAME_URL_PATH;
   const paramsString = encodeURIComponent(JSON.stringify(psicashParams_));
-  let iframeSrc = `${psicashParams_.widgetOrigin}${iframeURLPath}#`;
+  let iframeSrc = `${psicashParams_.widgetOrigin}${iframeURLPath}#!`;
   iframeSrc += `${common.PSICASH_URL_PARAM}=${paramsString}`;
   if (psicashParams_.dev !== null && psicashParams_.dev !== undefined) {
     iframeSrc += `&dev=${psicashParams_.dev}`;


### PR DESCRIPTION
Using #! prevents the parameter from accidentally functioning as a jump-to anchor on a landing page (where we have no power over element IDs).