### PR TITLE
Change Cache-Control to must-revalidate

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -134,7 +134,7 @@ function s3Upload() {
 
   // define custom headers
   var headers = {
-    'Cache-Control': 'max-age=315360000, no-transform, public'
+    'Cache-Control': 'must-revalidate, public'
   };
 
   return gulp


### PR DESCRIPTION
It's too much of a hassle to roll out new code with aggressive caching. And we can't use simple cache-busting techniques because there are so many pages that would need updating every time. This is probably the best compromise.